### PR TITLE
Changed usage of site values to accommodate nil values

### DIFF
--- a/discourse_comments.rb
+++ b/discourse_comments.rb
@@ -2,8 +2,8 @@
 #
 # Generates Discourse comments for posts
 #
-# Author: Blake Erickson
-# Site: http://blakeerickson.com
+# Author: Blake Erickson, Justin Gordon
+# Site: http://blakeerickson.com, http://www.railsonmaui.com and http://forum.railsonmaui.com
 # Plugin Source: http://github.com/oblakeerickson/jekyll_discourse_comments
 # Plugin License: MIT
 
@@ -29,7 +29,7 @@ module Jekyll
         <div id="discourse-comments"></div>
         <script type="text/javascript">
           var discourseUrl = "#{@site.config['discourse_url']}",
-              discourseEmbedUrl = "#{@site.config['url'] + @site.config['baseurl'] + url}";
+              discourseEmbedUrl = "#{@site.config['url']}#{@site.config['baseurl']}#{url}";
 
           (function() {
             var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;


### PR DESCRIPTION
- baseurl is often not configured for Octopress sites, so the value is nil,
  and the prior code would insert a literal "nil" in the URL.
